### PR TITLE
Add React Table

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,9 @@ Awesome list of React headless components! PRs are welcome.
 - [React Loads](https://github.com/jxom/react-loads) - A headless React component to handle promise states and response data.
 - [Restful React](https://github.com/contiamo/restful-react) - A set of data-fetching components that abstract away the state of requests, providing data to their children.
 
+### Tables
+- [React Table](https://github.com/tannerlinsley/react-table) - Hooks for building lightweight, fast and extendable datagrids for React.
+
 ## Articles
 
 - [Headless User Interface Components](https://medium.com/merrickchristensen/headless-user-interface-components-565b0c0f2e18) by [iammerrick](https://github.com/iammerrick)


### PR DESCRIPTION
[React Table](https://github.com/tannerlinsley/react-table) have moved to a headless approach in their v7 release.