### PR TITLE
Clarify the terminology of Base UI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ Awesome list of React headless components! PRs are welcome.
 - [use-select](https://github.com/tannerlinsley/use-select) - A react-hook for building enhanced input components.
 - [React Aria](https://react-spectrum.adobe.com/react-aria/index.html) - A library of React Hooks that provides accessible UI primitives for your design system.
 - [React Hook Form](https://github.com/react-hook-form/react-hook-form) - React Hooks for forms validation (Web + React Native)
-- [MUI Base](https://github.com/mui/material-ui/tree/master/packages/mui-base) - MUI, but without the Material Design implementation.
+- [Base UI](https://mui.com/base-ui/getting-started/) - Material UI, but without the Material Design styles.
 - [veccu/react-calendar](https://github.com/veccu/react-calendar) - React Hooks for building extensible calendar user interface
 - [React Headless MDE](https://github.com/webbrother/react-headless-mde) - React headless markdown editor
 - [Reach UI](https://reach.tech/) - Accessible components for your React-based design system

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ Awesome list of React headless components! PRs are welcome.
 - [use-select](https://github.com/tannerlinsley/use-select) - A react-hook for building enhanced input components.
 - [React Aria](https://react-spectrum.adobe.com/react-aria/index.html) - A library of React Hooks that provides accessible UI primitives for your design system.
 - [React Hook Form](https://github.com/react-hook-form/react-hook-form) - React Hooks for forms validation (Web + React Native)
-- [Base UI](https://mui.com/base-ui/getting-started/) - Material UI, but without the Material Design styles.
+- [Base UI](https://mui.com/base-ui/) - Material UI, but without the Material Design styles.
 - [veccu/react-calendar](https://github.com/veccu/react-calendar) - React Hooks for building extensible calendar user interface
 - [React Headless MDE](https://github.com/webbrother/react-headless-mde) - React headless markdown editor
 - [Reach UI](https://reach.tech/) - Accessible components for your React-based design system


### PR DESCRIPTION
We changed the name of "MUI Base" to "Base UI" to removes the confusion with Material Design. Also MUI is the organization.

cc @michaldudak This page returns 1st on Google when searching for "react headless components".

A continuation of #16.